### PR TITLE
BugID0005:Fixed nullptr conversion for strings.

### DIFF
--- a/cscpp-23899/CsharpToCppConverter/SharpToCppInterpreter.cs
+++ b/cscpp-23899/CsharpToCppConverter/SharpToCppInterpreter.cs
@@ -2400,8 +2400,10 @@ namespace Converters
                 case CsTokenType.New:
                     break;
                 case CsTokenType.Null:
-
-                    this.cppWriter.Write("nullptr");
+                    /* BugID0005:Fixed nullptr conversion for strings.
+                     * instead of nullptr write empty string as definition.
+                     */
+                    this.cppWriter.Write("\"\"");
                     return;
 
                 case CsTokenType.NullableTypeSymbol:


### PR DESCRIPTION
Instead of nullptr write empty string as definition.
